### PR TITLE
adds basic amazonKey init

### DIFF
--- a/integrations/amazonKeys/cli/init.sh
+++ b/integrations/amazonKeys/cli/init.sh
@@ -14,6 +14,14 @@ print_help() {
   "
 }
 
+is_empty () {
+  [ -z $1 ] || [ $1 == "null" ]
+}
+
+has_scope () {
+  [[ $SCOPES =~ (^|,)$1(,|$) ]]
+}
+
 parse_args() {
   if [ "$#" -gt 0 ]; then
     key="$1"
@@ -36,26 +44,56 @@ parse_args() {
   fi
 }
 
-configure_aws_cli () {
+check_and_set_vars () {
   AWS_ACCESS_KEY="$( shipctl get_integration_resource_field $RESOURCE_NAME "accessKey" )"
   AWS_SECRET_KEY="$( shipctl get_integration_resource_field $RESOURCE_NAME "secretKey" )"
-
   RESOURCE_VERSION_PATH="$(shipctl get_resource_meta $RESOURCE_NAME)/version.json"
   AWS_REGION="$( shipctl get_json_value $RESOURCE_VERSION_PATH "propertyBag.yml.pointer.region" )"
 
+  if is_empty "$AWS_ACCESS_KEY"; then
+    echo "Missing 'accessKey' value in $RESOURCE_NAME's integration."
+    exit 1
+  fi
+
+  if is_empty "$AWS_SECRET_KEY"; then
+    echo "Missing 'secretKey' value in $RESOURCE_NAME's integration."
+    exit 1
+  fi
+
+  if is_empty "$AWS_REGION"; then
+    echo "Missing 'region' value in pointer section of $RESOURCE_NAME's yml"
+    exit 1
+  fi
+}
+
+_configure_aws_cli () {
   aws configure set aws_access_key_id $AWS_ACCESS_KEY
   aws configure set aws_secret_access_key $AWS_SECRET_KEY
   aws configure set region $AWS_REGION
+
+  echo "Successfully configured aws cli."
+}
+
+_configure_aws_ecr () {
+  # TODO: complete aws ecr login script
+  echo "Successfully configured aws ecr."
 }
 
 init() {
   echo "Setting up $SCOPES for resource $RESOURCE_NAME."
 
-  configure_aws_cli
+  if has_scope "configure"; then
+    _configure_aws_cli
+  fi
+
+  if has_scope "ecr"; then
+    _configure_aws_ecr
+  fi
 }
 
 main() {
   parse_args "${ARGS[@]}"
+  check_and_set_vars
   init
 }
 

--- a/integrations/amazonKeys/cli/init.sh
+++ b/integrations/amazonKeys/cli/init.sh
@@ -33,9 +33,6 @@ parse_args() {
       *)
         RESOURCE_NAME=$1
         SCOPES=$2
-        if [ "$SCOPES" == "" ]; then
-          SCOPES="configure"
-        fi
         ;;
     esac
   else
@@ -76,15 +73,17 @@ _configure_aws_cli () {
 
 _configure_aws_ecr () {
   # TODO: complete aws ecr login script
+
   echo "Successfully configured aws ecr."
 }
 
 init() {
-  echo "Setting up $SCOPES for resource $RESOURCE_NAME."
-
-  if has_scope "configure"; then
-    _configure_aws_cli
+  echo "Setting up tools for $RESOURCE_NAME."
+  if [ ! -z $SCOPES ]; then
+    echo "Found scopes: $SCOPES"
   fi
+
+  _configure_aws_cli
 
   if has_scope "ecr"; then
     _configure_aws_ecr

--- a/integrations/amazonKeys/cli/init.sh
+++ b/integrations/amazonKeys/cli/init.sh
@@ -5,12 +5,12 @@ readonly SCRIPT_NAME="$( basename "$0" )"
 readonly ARGS=("$@")
 
 export RESOURCE_NAME=""
-export SCOPE=""
+export SCOPES=""
 
 print_help() {
   echo "
   Usage:
-    $SCRIPT_NAME <resource_name> [scope]
+    $SCRIPT_NAME <resource_name> [scopes]
   "
 }
 
@@ -24,9 +24,9 @@ parse_args() {
         ;;
       *)
         RESOURCE_NAME=$1
-        SCOPE=$2
-        if [ "$SCOPE" == "" ]; then
-          SCOPE="configure"
+        SCOPES=$2
+        if [ "$SCOPES" == "" ]; then
+          SCOPES="configure"
         fi
         ;;
     esac
@@ -36,8 +36,22 @@ parse_args() {
   fi
 }
 
+configure_aws_cli () {
+  AWS_ACCESS_KEY="$( shipctl get_integration_resource_field $RESOURCE_NAME "accessKey" )"
+  AWS_SECRET_KEY="$( shipctl get_integration_resource_field $RESOURCE_NAME "secretKey" )"
+
+  RESOURCE_VERSION_PATH="$(shipctl get_resource_meta $RESOURCE_NAME)/version.json"
+  AWS_REGION="$( shipctl get_json_value $RESOURCE_VERSION_PATH "propertyBag.yml.pointer.region" )"
+
+  aws configure set aws_access_key_id $AWS_ACCESS_KEY
+  aws configure set aws_secret_access_key $AWS_SECRET_KEY
+  aws configure set region $AWS_REGION
+}
+
 init() {
-  echo "Setting up $SCOPE for resource $RESOURCE_NAME."
+  echo "Setting up $SCOPES for resource $RESOURCE_NAME."
+
+  configure_aws_cli
 }
 
 main() {


### PR DESCRIPTION
https://github.com/Shippable/execTemplates/issues/11

Used the following YMLs to test

#### shippable.resources.yml
```yml
resources:
  - name: awsKeys-for-ec2
    type: cliConfig
    integration: test-aws
    pointer:
      region: us-west-2
```

#### shippable.jobs.yml
```yml

jobs:
  - name: amazonKeys-basic
    type: runSh
    steps:
      - IN: awsKeys-for-ec2
      - TASK:
        - script: echo "Listing running instances..."
        - script: aws ec2 describe-instances
        - script: echo "access key value -- $AWS_ACCESS_KEY -- should not be visible here"
        
  - name: amazonKeys-ecr
    type: runSh
    steps:
      - IN: awsKeys-for-ec2
        scopes:
          - ecr
      - TASK:
        - script: echo "ecr push will be implemented here"
```

If `region` is not present in the `pointer` of the resource , the following error is visible to user.

![selection_112](https://user-images.githubusercontent.com/4211715/30856428-f63af108-a2d5-11e7-9b2a-e1bd646faa59.png)

