### PR TITLE
#126; updates file resource sourceName in init.sh scripts.

### DIFF
--- a/CentOS_7/resources/file/init.sh
+++ b/CentOS_7/resources/file/init.sh
@@ -25,10 +25,10 @@ help() {
 check_params() {
   _log_msg "Checking params"
 
-  FILE_URI="$( shipctl get_json_value "$RESOURCE_META_PATH/version.json" "propertyBag.yml.pointer.sourceName" )"
+  FILE_URI="$( shipctl get_json_value "$RESOURCE_META_PATH/version.json" "version.propertyBag.sourceName" )"
 
   if _is_empty "$FILE_URI"; then
-    _log_err "Missing 'pointer.sourceName' value in YML for $RESOURCE_NAME."
+    _log_err "Missing 'sourceName' value in version for $RESOURCE_NAME."
     exit 1
   fi
 

--- a/Ubuntu_14.04/resources/file/init.sh
+++ b/Ubuntu_14.04/resources/file/init.sh
@@ -25,10 +25,10 @@ help() {
 check_params() {
   _log_msg "Checking params"
 
-  FILE_URI="$( shipctl get_json_value "$RESOURCE_META_PATH/version.json" "propertyBag.yml.pointer.sourceName" )"
+  FILE_URI="$( shipctl get_json_value "$RESOURCE_META_PATH/version.json" "version.propertyBag.sourceName" )"
 
   if _is_empty "$FILE_URI"; then
-    _log_err "Missing 'pointer.sourceName' value in YML for $RESOURCE_NAME."
+    _log_err "Missing 'sourceName' value in version for $RESOURCE_NAME."
     exit 1
   fi
 

--- a/Ubuntu_16.04/resources/file/init.sh
+++ b/Ubuntu_16.04/resources/file/init.sh
@@ -25,10 +25,10 @@ help() {
 check_params() {
   _log_msg "Checking params"
 
-  FILE_URI="$( shipctl get_json_value "$RESOURCE_META_PATH/version.json" "propertyBag.yml.pointer.sourceName" )"
+  FILE_URI="$( shipctl get_json_value "$RESOURCE_META_PATH/version.json" "version.propertyBag.sourceName" )"
 
   if _is_empty "$FILE_URI"; then
-    _log_err "Missing 'pointer.sourceName' value in YML for $RESOURCE_NAME."
+    _log_err "Missing 'sourceName' value in version for $RESOURCE_NAME."
     exit 1
   fi
 

--- a/macOS_10.12/resources/file/init.sh
+++ b/macOS_10.12/resources/file/init.sh
@@ -25,10 +25,10 @@ help() {
 check_params() {
   _log_msg "Checking params"
 
-  FILE_URI="$( shipctl get_json_value "$RESOURCE_META_PATH/version.json" "propertyBag.yml.pointer.sourceName" )"
+  FILE_URI="$( shipctl get_json_value "$RESOURCE_META_PATH/version.json" "version.propertyBag.sourceName" )"
 
   if _is_empty "$FILE_URI"; then
-    _log_err "Missing 'pointer.sourceName' value in YML for $RESOURCE_NAME."
+    _log_err "Missing 'sourceName' value in version for $RESOURCE_NAME."
     exit 1
   fi
 


### PR DESCRIPTION
#126 

Tested by copying one version of the script (they're identical) into a genExec container and running it in a runSh job.  It was able to find the sourceName.