### PR TITLE
#162; adds replace_placeholders scripts.

### DIFF
--- a/CentOS_7/job/replace_placeholders.sh
+++ b/CentOS_7/job/replace_placeholders.sh
@@ -1,0 +1,11 @@
+
+replace_placeholders() {
+  VERSION_PATH=<%= obj.versionPath %>
+  if [ -f "$VERSION_PATH" ]; then
+    {
+      exec_cmd "shippable_replace $VERSION_PATH"
+    } || true
+  fi
+}
+
+replace_placeholders

--- a/Ubuntu_14.04/job/replace_placeholders.sh
+++ b/Ubuntu_14.04/job/replace_placeholders.sh
@@ -1,0 +1,11 @@
+
+replace_placeholders() {
+  VERSION_PATH=<%= obj.versionPath %>
+  if [ -f "$VERSION_PATH" ]; then
+    {
+      exec_cmd "shippable_replace $VERSION_PATH"
+    } || true
+  fi
+}
+
+replace_placeholders

--- a/Ubuntu_16.04/job/replace_placeholders.sh
+++ b/Ubuntu_16.04/job/replace_placeholders.sh
@@ -1,0 +1,11 @@
+
+replace_placeholders() {
+  VERSION_PATH=<%= obj.versionPath %>
+  if [ -f "$VERSION_PATH" ]; then
+    {
+      exec_cmd "shippable_replace $VERSION_PATH"
+    } || true
+  fi
+}
+
+replace_placeholders

--- a/WindowsServer_2016/job/replace_placeholders.ps1
+++ b/WindowsServer_2016/job/replace_placeholders.ps1
@@ -1,0 +1,5 @@
+Function replace_placeholders() {
+    exec_cmd 'shippable_replace <%= cmd %>'
+}
+
+replace_placeholders

--- a/macOS_10.12/job/replace_placeholders.sh
+++ b/macOS_10.12/job/replace_placeholders.sh
@@ -1,0 +1,11 @@
+
+replace_placeholders() {
+  VERSION_PATH=<%= obj.versionPath %>
+  if [ -f "$VERSION_PATH" ]; then
+    {
+      exec_cmd "shippable_replace $VERSION_PATH"
+    } || true
+  fi
+}
+
+replace_placeholders


### PR DESCRIPTION
#162 

Tested on Ubuntu 14.04 and Centos 7.  Ubuntu 16.04 and Mac are identical and will be tested in RC.  I was not able to test the Windows script because I was unable to initialize a Windows node.