### PR TITLE
Add helpers and logger for Windows resource scripts

### DIFF
--- a/WindowsServer_2016/resources/common/_helpers.ps1
+++ b/WindowsServer_2016/resources/common/_helpers.ps1
@@ -1,0 +1,5 @@
+$ErrorActionPreference = "Stop"
+
+function _csv_has_value([string] $csv, [string] $value) {
+    return $csv -match "(^|,)$value(,|$)"
+}

--- a/WindowsServer_2016/resources/common/_logger.ps1
+++ b/WindowsServer_2016/resources/common/_logger.ps1
@@ -1,0 +1,23 @@
+# These helpers use [Console]::Write because Write-Output will always add
+# new lines between each parameter
+
+$ErrorActionPreference = "Stop"
+
+function _log_grp() {
+    # Concat a string so the array gets formatted like we want it to be
+    [Console]::WriteLine("" + $args)
+}
+
+function _log_msg() {
+    [Console]::WriteLine("|___ " + $args)
+}
+
+function _log_err() {
+    # TODO: Figure out a way to get colours
+    _log_msg @args
+}
+
+function _log_success() {
+    # TODO: Figure out a way to get colours
+    _log_msg @args
+}


### PR DESCRIPTION
For #165 

1. _is_docker_email_deprecated has been left out because we only support Windows nodes with Docker 17.06 and above where the email flag is known to be deprecated

1. _is_jfrog_version_new is not part of the current scope.