### PR TITLE
Add amazonKeys resource scripts for Windows

### DIFF
--- a/WindowsServer_2016/resources/cliConfig/amazonKeys/cleanup.ps1
+++ b/WindowsServer_2016/resources/cliConfig/amazonKeys/cleanup.ps1
@@ -1,0 +1,63 @@
+$ErrorActionPreference = "Stop"
+
+$rootDir = "$PSScriptRoot\..\..\.."
+$commonDir = Join-Path "$rootDir" "\resources\common"
+$helpersPath = Join-Path "$commonDir" "_helpers.ps1"
+$loggerPath = Join-Path "$commonDir" "_logger.ps1"
+$scriptName = $MyInvocation.InvocationName
+
+. "$loggerPath"
+. "$helpersPath"
+
+function help() {
+@"
+Usage:
+    $scriptName <resource_name> [scopes]
+"@
+}
+
+function cleanup_scope_configure() {
+    _log_msg "Cleaning up scope configure"
+
+    $awsConfigPath = "~/.aws"
+
+    if (Test-Path -PathType Container "$awsConfigPath") {
+        Remove-Item -Force -Recurse "$awsConfigPath"
+    }
+
+    _log_success "Successfully cleaned up scope configure"
+}
+
+function cleanup_scope_ecr() {
+    # TODO: Figure out how to logout of all registries. Just deleting
+    # ~/.docker is not going to do anything useful because the creds
+    # are actually stored in the Windows Credential Manager
+
+    _log_msg "ecr scope cleanup is not yet supported on Windows"
+}
+
+function cleanup([string] $resourceName, [string] $scopes) {
+    _log_grp "Cleaning up resource $resourceName"
+
+    cleanup_scope_configure
+
+    if (_csv_has_value $scopes "ecr") {
+        cleanup_scope_ecr
+    }
+}
+
+function main() {
+    if ($args.Length -gt 0) {
+        if ($args[0] -eq "help") {
+            help
+            exit 0
+        } else {
+            cleanup @args
+        }
+    } else {
+        help
+        exit 1
+    }
+}
+
+main @args

--- a/WindowsServer_2016/resources/cliConfig/amazonKeys/init.ps1
+++ b/WindowsServer_2016/resources/cliConfig/amazonKeys/init.ps1
@@ -1,0 +1,102 @@
+$ErrorActionPreference = "Stop"
+
+$rootDir = "$PSScriptRoot\..\..\.."
+$commonDir = Join-Path "$rootDir" "\resources\common"
+$helpersPath = Join-Path "$commonDir" "_helpers.ps1"
+$loggerPath = Join-Path "$commonDir" "_logger.ps1"
+$scriptName = $MyInvocation.InvocationName
+
+. "$loggerPath"
+. "$helpersPath"
+
+$resourceName = ""
+$scopes = ""
+$awsAccessKey = ""
+$awsSecretKey = ""
+$resourceVersionPath = ""
+$awsRegion = ""
+
+function help() {
+@"
+Usage:
+    $scriptName <resource_name> [scopes]
+"@
+}
+
+function check_params() {
+    $script:awsAccessKey = shipctl get_integration_resource_field "$resourceName" "accessKey"
+    $script:awsSecretKey = shipctl get_integration_resource_field "$resourceName" "secretKey"
+    $script:resourceVersionpath = (shipctl get_resource_meta "$resourceName") + "/version.json"
+    $script:awsRegion = shipctl get_json_value $resourceVersionPath "version.propertyBag.region"
+
+    if (-not "$script:awsAccessKey") {
+        _log_err "Missing 'accessKey' value in $resourceName integration"
+        exit 1
+    }
+
+    if (-not "$script:awsSecretKey") {
+        _log_err "Missing 'secretKey' value in $resourceName integration"
+        exit 1
+    }
+
+    if (-not "$script:awsRegion") {
+        _log_err "Missing 'region' value in $resourceName integration"
+        exit 1
+    }
+
+    _log_success "Successfully checked params"
+}
+
+function init_scope_configure() {
+    _log_msg "Initializing scope configure"
+
+    & aws configure set aws_access_key_id $awsAccessKey
+    & aws configure set aws_secret_access_key $awsSecretKey
+    & aws configure set region $awsRegion
+
+    _log_success "Successfully initialized scope configure"
+}
+
+function init_scope_ecr() {
+    _log_msg "Initializing scope ecr"
+    $dockerLoginCommand = (aws ecr get-login --no-include-email)
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+    Invoke-Expression $dockerLoginCommand
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+    _log_msg "Successfully initialized scope ecr"
+}
+
+function init([string] $resourceName, [string] $scopes) {
+    $script:resourceName = $resourceName
+    $script:scopes = $scopes
+
+    _log_grp "Initializing AWS keys for resource $resourceName"
+
+    check_params
+
+    init_scope_configure
+
+    if (_csv_has_value "$scopes" "ecr") {
+        init_scope_ecr
+    }
+}
+
+function main() {
+    if ($args.Length -gt 0) {
+        if ($args[0] -eq "help") {
+            help
+            exit 0
+        } else {
+            init @args
+        }
+    } else {
+        help
+        exit 1
+    }
+}
+
+main @args


### PR DESCRIPTION
For #166 

Tested `init` and `cleanup` by setting the envs and a version.json file manually.

Cleanup will not do anything about docker login because there isn't a straighforward way to make it work on Windows. We will address this shortcoming later.

````
> .\init.ps1 myaws ecr
Initializing AWS keys for resource myaws
|___ Successfully checked params
|___ Initializing scope configure
|___ Successfully initialized scope configure
|___ Initializing scope ecr
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
Login Succeeded
|___ Successfully initialized scope ecr

> .\cleanup.ps1 myaws ecr
Cleaning up resource myaws
|___ Cleaning up scope configure
|___ Successfully cleaned up scope configure
|___ ecr scope cleanup is not yet supported on Windows
````

