### PR TITLE
Fix replace_placeholders.ps1 to match the other templates

### DIFF
--- a/WindowsServer_2016/job/replace_placeholders.ps1
+++ b/WindowsServer_2016/job/replace_placeholders.ps1
@@ -1,5 +1,8 @@
 Function replace_placeholders() {
-    exec_cmd 'shippable_replace <%= cmd %>'
+    $versionPath = "<%= obj.versionPath %>"
+    if (Test-Path "$versionPath") {
+        exec_cmd "shippable_replace $versionPath"
+    }
 }
 
 replace_placeholders


### PR DESCRIPTION
For #162 

Updates the PS1 template to match https://github.com/Shippable/execTemplates/blob/master/Ubuntu_16.04/job/replace_placeholders.sh