### PR TITLE
introduces group_close in exec_grp

### DIFF
--- a/WindowsServer_2016/job/header.ps1
+++ b/WindowsServer_2016/job/header.ps1
@@ -32,7 +32,7 @@ Function exec_cmd([string]$cmd) {
   }
 }
 
-Function exec_grp([string]$group_name, [string]$group_message,[Bool]$is_shown = $TRUE) {
+Function exec_grp([string]$group_name, [string]$group_message, [Bool]$is_shown = $TRUE, [Bool]$group_close = $TRUE) {
   if (-not ($group_message)) {
     group_message=$group_name
   }
@@ -45,6 +45,10 @@ Function exec_grp([string]$group_name, [string]$group_message,[Bool]$is_shown = 
 
   $group_status = 0
 
+  # export envs to provide information for closing the group outside exec_grp
+  $env:current_grp = $group_message
+  $env:current_grp_uuid = $group_uuid
+
   Try
   {
     Invoke-Expression $group_name
@@ -56,8 +60,13 @@ Function exec_grp([string]$group_name, [string]$group_message,[Bool]$is_shown = 
   }
   Finally
   {
-    $date_time = (Get-Date).ToUniversalTime()
-    $group_end_timestamp = [System.Math]::Truncate((Get-Date -Date $date_time -UFormat %s))
-    Write-Output "__SH__GROUP__END__|{`"type`":`"grp`",`"sequenceNumber`":`"$group_end_timestamp`",`"id`":`"$group_uuid`",`"is_shown`":`"$is_shown`",`"exitcode`":`"$group_status`"}|$group_message"
+    if ($group_close) {
+      $env:current_grp = ""
+      $env:current_grp_uuid = ""
+
+      $date_time = (Get-Date).ToUniversalTime()
+      $group_end_timestamp = [System.Math]::Truncate((Get-Date -Date $date_time -UFormat %s))
+      Write-Output "__SH__GROUP__END__|{`"type`":`"grp`",`"sequenceNumber`":`"$group_end_timestamp`",`"id`":`"group_uuid`",`"is_shown`":`"$is_shown`",`"exitcode`":`"$group_status`"}|$group_message"
+    }
   }
 }

--- a/WindowsServer_2016/job/task.ps1
+++ b/WindowsServer_2016/job/task.ps1
@@ -93,6 +93,18 @@ Function before_exit() {
       exec_cmd "always"
     <% } %>
 
+    if ($env:current_grp_uuid) {
+      $date_time = (Get-Date).ToUniversalTime()
+      $current_timestamp = [System.Math]::Truncate((Get-Date -Date $date_time -UFormat %s))
+
+      $group_status = 0
+      if ($global:FAIL_SHIPPABLE_BUILD) {
+        $group_status = 1
+      }
+
+      Write-Output "__SH__GROUP__END__|{`"type`":`"grp`",`"sequenceNumber`":`"$current_timestamp`",`"id`":`"$env:current_grp_uuid`",`"is_shown`":`"false`",`"exitcode`":`"$group_status`"}|$env:current_grp"
+    }
+
     if ($global:FAIL_SHIPPABLE_BUILD) {
       Write-Output "__SH__SCRIPT_END_FAILURE__";
     } else {
@@ -107,6 +119,14 @@ Function before_exit() {
       exec_cmd "always"
     <% } %>
 
+    if ($env:current_grp_uuid) {
+      $date_time = (Get-Date).ToUniversalTime()
+      $current_timestamp = [System.Math]::Truncate((Get-Date -Date $date_time -UFormat %s))
+      $group_status = 1
+
+      Write-Output "__SH__GROUP__END__|{`"type`":`"grp`",`"sequenceNumber`":`"$current_timestamp`",`"id`":`"$env:current_grp_uuid`",`"is_shown`":`"false`",`"exitcode`":`"$group_status`"}|$env:current_grp"
+    }
+
     Write-Output "__SH__SCRIPT_END_FAILURE__";
   }
 }
@@ -115,7 +135,7 @@ Function main() {
   $global:is_success = $TRUE
   Try
   {
-    exec_grp "task" "Executing Task $env:TASK_NAME"
+    exec_grp "task" "Executing Task $env:TASK_NAME" $TRUE $FALSE
   }
   Catch
   {


### PR DESCRIPTION
https://github.com/Shippable/execTemplates/issues/254

I am not exactly sure of the reason why we set `is_shown` flag to false always. I had set it by referencing the *nix scripts. Moreover, the builds seem to behave as expected with that setting. I would be glad to know the usage of `is_shown` in UI and the reason for why we set it the way we set it.

Verified by running 
- https://rcapp.shippable.com/github/sample-organisation/jobs/x86-64-windows-server-2016-host-sfa-on-success-time/builds/5a785a0049b01a0500b8f7b3/console
- https://rcapp.shippable.com/github/sample-organisation/jobs/x86-64-windows-server-2016-host-sfa-on-failure-time/builds/5a785aa349b01a0500b8f7b4/console
- https://rcapp.shippable.com/github/sample-organisation/jobs/x86-64-windows-server-2016-host-sfa-always-time/builds/5a785aa449b01a0500b8f7b6/console
- https://rcapp.shippable.com/github/sample-organisation/jobs/x86-64-windows-server-2016-host-sfa-on-success-always-time/builds/5a785aff49b01a0500b8f7b8/console
- https://rcapp.shippable.com/github/sample-organisation/jobs/x86-64-windows-server-2016-host-sfa-on-failure-always-time/builds/5a785b0449b01a0500b8f7ba/console