### PR TITLE
escapes command inside the task section

### DIFF
--- a/WindowsServer_2016/job/task.ps1
+++ b/WindowsServer_2016/job/task.ps1
@@ -24,7 +24,9 @@ Function Fail-ShippableBuild() {
 Function task() {
   init_integrations
   <% _.each(obj.script, function(cmd) { %>
-    exec_cmd '<%= cmd %>'
+exec_cmd @'
+<%= cmd %>
+'@
   <% }) %>
   cleanup_integrations
 }


### PR DESCRIPTION
https://github.com/Shippable/execTemplates/issues/256

verified for the following yml's:
1. 
```  - name: windows_simple_non_zero_exit_multiline
    type: runSh
    runtime:
      nodePool: custom__x86_64__WindowsServer_2016
      container: false
    steps:
    - TASK:
        name: non_zero_exit_multiline
        script: |
          echo "shouldn't come here"
          echo "shouldn't come here agai'n"
          ls
```
![image](https://user-images.githubusercontent.com/11424742/36089807-aa125456-1003-11e8-8dd7-7e17e061bbf6.png)

2. 
jobs:
  - name: windows_simple_non_zero_exit
    type: runSh
    runtime:
      nodePool: custom__x86_64__WindowsServer_2016
      container: false
    steps:
    - TASK:
        name: non_zero_exit
        script:
          - $foo = "bar"
          - echo $foo
          - echo "shouldn't come here"

![image](https://user-images.githubusercontent.com/11424742/36089826-be2c89a2-1003-11e8-90f9-872205dc527f.png)
