### PR TITLE
escapes command inside the on_success, on_failure and always section

### DIFF
--- a/WindowsServer_2016/job/task.ps1
+++ b/WindowsServer_2016/job/task.ps1
@@ -36,7 +36,9 @@ Function on_success() {
   <% _.each(obj.onSuccess.script, function(cmd) { %>
     Try
     {
-      Invoke-Expression '<%= cmd %>'
+Invoke-Expression @'
+<%= cmd %>
+'@
     }
     Catch
     {
@@ -54,7 +56,9 @@ Function on_failure() {
   <% _.each(obj.onFailure.script, function(cmd) { %>
     Try
     {
-      Invoke-Expression '<%= cmd %>'
+Invoke-Expression @'
+<%= cmd %>
+'@
     }
     Catch
     {
@@ -72,7 +76,9 @@ Function always() {
   <% _.each(obj.always.script, function(cmd) { %>
     Try
     {
-      Invoke-Expression '<%= cmd %>'
+Invoke-Expression @'
+<%= cmd %>
+'@
     }
     Catch
     {


### PR DESCRIPTION
https://github.com/Shippable/execTemplates/issues/257

**for on_success:**
yml:
```
    on_success:
      - script: echo "works!!! :("
      - script: echo $foo
      - script: $foo = "baz"
      - script: echo $foo
      - script: echo "'work's;"
```
![image](https://user-images.githubusercontent.com/11424742/36091791-0226d67e-100b-11e8-88ee-92bc780dfec8.png)

```
    on_success:
      - script: |
          ls
          echo "hello :)"
          echo "script is success & work's"
```
![image](https://user-images.githubusercontent.com/11424742/36091765-e87f3c34-100a-11e8-9c55-c79bb71e401b.png)


**for on_failure:**
yml
```
    on_failure:
      - script: echo "failure :("
      - script: echo $foo
      - script: $foo = "baz"
      - script: echo $foo
      - script: echo "failed"
```
![image](https://user-images.githubusercontent.com/11424742/36091865-4929539e-100b-11e8-8ba2-e7c95e081126.png)

```
    on_failure:
      - script: |
          ps
          echo "does not work's"
```
![image](https://user-images.githubusercontent.com/11424742/36091924-866ecd10-100b-11e8-8f03-bcb1ce9efa1f.png)

**for always**:
yml:

```
    always:
      - script: echo $foo
      - script: $foo = "always"
      - script: echo $foo
      - script: echo "always done"
```
![image](https://user-images.githubusercontent.com/11424742/36091980-bb700506-100b-11e8-9d94-3bbe46cc830f.png)


```
    always:
      - script: |
          pwd
          echo "hello from the always section"
          echo "always work's"
```
![image](https://user-images.githubusercontent.com/11424742/36091966-af5847d8-100b-11e8-8bd0-5432f7a3ff09.png)


