### PR TITLE
Allow failures in copying PEM keys

### DIFF
--- a/CentOS_7/job/task.sh
+++ b/CentOS_7/job/task.sh
@@ -9,7 +9,7 @@ symlink_build_dir() {
 
 # Adding this to support legacy genExec PEM key path
 copy_pem_keys() {
-  cp $BUILD_SECRETS_DIR/*.pem /tmp
+  exec_cmd "cp $BUILD_SECRETS_DIR/*.pem /tmp || true"
 }
 
 add_subscription_ssh_key() {

--- a/Ubuntu_14.04/job/task.sh
+++ b/Ubuntu_14.04/job/task.sh
@@ -9,7 +9,7 @@ symlink_build_dir() {
 
 # Adding this to support legacy genExec PEM key path
 copy_pem_keys() {
-  cp $BUILD_SECRETS_DIR/*.pem /tmp
+  exec_cmd "cp $BUILD_SECRETS_DIR/*.pem /tmp || true"
 }
 
 add_subscription_ssh_key() {

--- a/Ubuntu_16.04/job/task.sh
+++ b/Ubuntu_16.04/job/task.sh
@@ -9,7 +9,7 @@ symlink_build_dir() {
 
 # Adding this to support legacy genExec PEM key path
 copy_pem_keys() {
-  cp $BUILD_SECRETS_DIR/*.pem /tmp
+  exec_cmd "cp $BUILD_SECRETS_DIR/*.pem /tmp || true"
 }
 
 add_subscription_ssh_key() {

--- a/macOS_10.12/job/task.sh
+++ b/macOS_10.12/job/task.sh
@@ -9,7 +9,7 @@ symlink_build_dir() {
 
 # Adding this to support legacy genExec PEM key path
 copy_pem_keys() {
-  cp $BUILD_SECRETS_DIR/*.pem /tmp
+  exec_cmd "cp $BUILD_SECRETS_DIR/*.pem /tmp || true"
 }
 
 add_subscription_ssh_key() {


### PR DESCRIPTION
`cp` complains if there are no PEM keys found while copying. This would mean any build without a gitRepo as an IN were failing. While this is not ideal, we might want to find and copy the files we need, this should be sufficient as this is only for backward compatibility.

https://github.com/Shippable/execTemplates/issues/262