### PR TITLE
fixes issue of messy logs in case on blocked yml notations in U14

### DIFF
--- a/Ubuntu_14.04/job/header.sh
+++ b/Ubuntu_14.04/job/header.sh
@@ -107,7 +107,8 @@ exec_cmd() {
   # If cmd output has no newline at end, marker parsing
   # would break. Hence force a newline before the marker.
   echo ""
-  echo "__SH__CMD__END__|{\"type\":\"cmd\",\"sequenceNumber\":\"$cmd_start_timestamp\",\"id\":\"$cmd_uuid\",\"exitcode\":\"$cmd_status\"}|$cmd"
+  local cmd_first_line=$(printf "$cmd" | head -n 1)
+  echo "__SH__CMD__END__|{\"type\":\"cmd\",\"sequenceNumber\":\"$cmd_start_timestamp\",\"id\":\"$cmd_uuid\",\"exitcode\":\"$cmd_status\"}|$cmd_first_line"
   return $cmd_status
 }
 


### PR DESCRIPTION
https://github.com/Shippable/execTemplates/issues/275

- here is the yml
```yml
jobs:
  - name: sample-job-A
    type: runSh
    steps:
      - TASK:
          script:
            - echo "This is job B"
            - |
              echo "starting TEST"
              sleep 10
              touch hello.txt
              echo "hello" >> hello.txt
              echo "world" >> hello.txt
              echo "So here is the file that we created"; cat hello.txt
              echo "thanks"
            - echo "other script"
            - echo "some other script 1"
```

- console groups closed
![image](https://user-images.githubusercontent.com/14016521/40606048-c6d245b2-6281-11e8-90b1-7bcec54a512f.png)


- console groups open
![image](https://user-images.githubusercontent.com/14016521/40606073-d566d08e-6281-11e8-9ee8-da5adebdf1d2.png)
