### PR TITLE
fixes issue of messy logs in case on blocked yml notations in Centos_7

### DIFF
--- a/CentOS_7/job/header.sh
+++ b/CentOS_7/job/header.sh
@@ -107,7 +107,8 @@ exec_cmd() {
   # If cmd output has no newline at end, marker parsing
   # would break. Hence force a newline before the marker.
   echo ""
-  echo "__SH__CMD__END__|{\"type\":\"cmd\",\"sequenceNumber\":\"$cmd_start_timestamp\",\"id\":\"$cmd_uuid\",\"exitcode\":\"$cmd_status\"}|$cmd"
+  local cmd_first_line=$(printf "$cmd" | head -n 1)
+  echo "__SH__CMD__END__|{\"type\":\"cmd\",\"sequenceNumber\":\"$cmd_start_timestamp\",\"id\":\"$cmd_uuid\",\"exitcode\":\"$cmd_status\"}|$cmd_first_line"
   return $cmd_status
 }
 


### PR DESCRIPTION
https://github.com/Shippable/execTemplates/issues/277

- here is the yml
```yml
jobs:
  - name: sample-job-A
    type: runSh
    steps:
      - TASK:
          script:
            - echo "This is job B"
            - |
              echo "starting TEST"
              sleep 10
              touch hello.txt
              echo "hello" >> hello.txt
              echo "world" >> hello.txt
              echo "So here is the file that we created"; cat hello.txt
              echo "thanks"
            - echo "other script"
            - echo "some other script 1"
```

- console groups closed
![image](https://user-images.githubusercontent.com/14016521/40609824-859bf76c-628d-11e8-8ce9-281bd9f799f9.png)

- console groups open
![image](https://user-images.githubusercontent.com/14016521/40609835-9165ac96-628d-11e8-8667-b5f69c2c35b7.png)

