### PR TITLE
fixes issue of messy logs in case on blocked yml notations in MacOs

### DIFF
--- a/macOS_10.12/job/header.sh
+++ b/macOS_10.12/job/header.sh
@@ -107,7 +107,8 @@ exec_cmd() {
   # If cmd output has no newline at end, marker parsing
   # would break. Hence force a newline before the marker.
   echo ""
-  echo "__SH__CMD__END__|{\"type\":\"cmd\",\"sequenceNumber\":\"$cmd_start_timestamp\",\"id\":\"$cmd_uuid\",\"exitcode\":\"$cmd_status\"}|$cmd"
+  local cmd_first_line=$(printf "$cmd" | head -n 1)
+  echo "__SH__CMD__END__|{\"type\":\"cmd\",\"sequenceNumber\":\"$cmd_start_timestamp\",\"id\":\"$cmd_uuid\",\"exitcode\":\"$cmd_status\"}|$cmd_first_line"
   return $cmd_status
 }
 


### PR DESCRIPTION
https://github.com/Shippable/execTemplates/issues/278

- Mac supports `printf` so this should work. printf [docs](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/printf.1.html) for mac bash.

- Mac is broken now so couldnt test. This will be tested whenever MAC works. We can merge this now.